### PR TITLE
change action name and path

### DIFF
--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: WordPress.org plugin asset/readme update
-      uses: 10up/actions-wordpress/dotorg-plugin-asset-update@master
+      uses: 10up/action-wordpress-plugin-asset-update@stable
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
Resolve this error on the github action workflow:

```
Download action repository 'actions/checkout@master' (SHA:85e6279cec87321a52edac9c87bce653a07cf6c2)
Error: Missing download info for 10up/actions-wordpress@master
```